### PR TITLE
release.sh: New file.

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Create a tar file from the current sources for e.g. Marmalade.
+
+VERSION="$(sed -ne 's/^;; Version: *\([0-9.]*\)/\1/p' iedit.el)"
+
+mkdir -p release
+mkdir -p "release/iedit-$VERSION"
+cp *.el README.org "release/iedit-$VERSION"
+echo "(define-package \"iedit\" \"$VERSION\" \"Edit multiple regions in the same way simultaneously.\" '())" > "release/iedit-$VERSION/iedit-pkg.el"
+
+AUTOLOADS="$(pwd)/release/iedit-$VERSION/iedit-autoloads.el"
+emacs -q --batch --eval \
+  "(let ((generated-autoload-file \"$AUTOLOADS\"))
+     (batch-update-autoloads))" \
+  "release/iedit-$VERSION"
+rm -f "release/iedit-$VERSION"/*.el~
+tar -C release -c "iedit-$VERSION" > "release/iedit-${VERSION}.tar"
+rm -rf "release/iedit-$VERSION"
+
+echo
+echo "Release read for upload in release/iedit-${VERSION}.tar"


### PR DESCRIPTION
This file will create a new ELPA-compatible release from iedit. The
resulting .tar file can be uploaded to e.g. the Marmalade repository,
and be re-used by other users from there.

I have taken the liberty of adding an iedit package to the Marmalade
ELPA repository: http://marmalade-repo.org/packages/iedit/0.97

The shell script in this commit was the one I used to create the
package I uploaded.

If you would like to take over maintainership of the package on
marmalade, I'm very happy to pass it on :-)
