### PR TITLE
ensure iedit-skip-modification-once is t in case of errors

### DIFF
--- a/iedit-rect.el
+++ b/iedit-rect.el
@@ -93,6 +93,10 @@ Commands:
   (interactive (when (iedit-region-active)
                  (list (region-beginning)
                        (region-end))))
+
+  ;; enforce skip modification once, errors may happen to cause this to be
+  ;; unset.
+  (setq iedit-skip-modification-once t)
   (if iedit-rectangle-mode
       (iedit-rectangle-done)
     (iedit-barf-if-lib-active)

--- a/iedit.el
+++ b/iedit.el
@@ -375,6 +375,10 @@ Keymap used within overlays:
 
 (defun iedit-start (occurrence-regexp beg end)
   "Start Iedit mode for the `occurrence-regexp' in the current buffer."
+
+  ;; enforce skip modification once, errors may happen to cause this to be
+  ;; unset.
+  (setq iedit-skip-modification-once t)
   (setq iedit-unmatched-lines-invisible iedit-unmatched-lines-invisible-default)
   (setq iedit-initial-region (list beg end))
   (iedit-start2 occurrence-regexp beg end)


### PR DESCRIPTION
I noticed some times at the entry points modified `iedit-skip-modification-once1` is nil which causes all kinds of strange errors.

I've used this patch for a little over a month, and it doesn't seem to have any bad side effects.
