### PR TITLE
Clean up the occurrence string presented to the user

### DIFF
--- a/iedit-lib.el
+++ b/iedit-lib.el
@@ -836,17 +836,21 @@ Return nil if occurrence string is empty string."
 
 (defun iedit-printable (string)
   "Return a omitted substring that is not longer than 50.
-STRING is already `regexp-quote'ed"
-  (let ((first-newline-index (string-match "$" string))
-        (length (length string)))
+STRING is already `regexp-quote'ed. If extra characters were
+added to make this string only match symbols (i.e. if
+iedit-only-complete-symbol-local is non-nil) then strip those
+extra characters off."
+  (let* ((clean-string (iedit-regexp-maybe-unquote string))
+         (first-newline-index (string-match "$" clean-string))
+         (length (length clean-string)))
     (if (and first-newline-index
              (/= first-newline-index length))
         (if (< first-newline-index 50)
-            (concat (substring string 0 first-newline-index) "...")
-          (concat (substring string 0 50) "..."))
+            (concat (substring clean-string 0 first-newline-index) "...")
+          (concat (substring clean-string 0 50) "..."))
       (if (> length 50)
-          (concat (substring string 0 50) "...")
-        string))))
+          (concat (substring clean-string 0 50) "...")
+        clean-string))))
 
 (defun iedit-region-active ()
   "Return t if region is active and not empty.

--- a/iedit.el
+++ b/iedit.el
@@ -393,6 +393,13 @@ Keymap used within overlays:
       (concat "\\_<" (regexp-quote exp) "\\_>")
     (regexp-quote exp)))
 
+(defun iedit-regexp-maybe-unquote (exp)
+  "Strip off the extra regexp characters that
+`iedit-regexp-quote' adds to a string."
+  (if iedit-only-complete-symbol-local
+      (substring exp 3 (- (length exp) 3))
+    exp))
+
 (defun iedit-start2 (occurrence-regexp beg end)
   "Refresh Iedit mode."
   (setq iedit-occurrence-keymap iedit-mode-occurrence-keymap)


### PR DESCRIPTION
If `iedit-only-complete-symbol-*' is being used then there are some
extra characters added to the occurrence string which make the string
a regexp to only match symbols. The user doesn't need to know what the
regexp looks like, they only care about the occurrence string, so
clean up the added characters if necessary when presenting the
occurrence string to the user.
