### PR TITLE
Provide functions to narrow around current-line

### DIFF
--- a/README.org
+++ b/README.org
@@ -35,6 +35,14 @@ Renaming refactoring is convinient in Iedit mode
  - Last renaming refactoring is remembered and can be applied to other buffers
    later
 
+ - Restricting the search area to just the current line can be done by
+   pressing M-I.
+
+ - Restricting the search area to the lines near the current line can
+   be done by pressing M-{ and M-}. These will expand the search
+   region one line at a time from the top and bottom. Add a prefix
+   argument to go the opposite direction.
+
 Iedit-rectangle-mode provides rectangle support with *visible rectangle*
 highlighting, which is similar with cua mode rectangle support.  But it's
 lighter weight and uses iedit mechanisms.

--- a/iedit-lib.el
+++ b/iedit-lib.el
@@ -848,6 +848,25 @@ STRING is already `regexp-quote'ed"
           (concat (substring string 0 50) "...")
         string))))
 
+(defun iedit-char-at-bol (&optional N)
+  "Get char position of the beginning of the current line. If `N'
+is given, move forward (or backward) that many lines (using
+`forward-line') and get the char position at the beginning of
+that line."
+  (save-excursion
+    (forward-line (if N N 0))
+    (point)))
+
+(defun iedit-char-at-eol (&optional N)
+  "Get char position of the end of the current line. If `N' is
+given, move forward (or backward) that many lines (using
+`forward-line') and get the char position at the end of that
+line."
+  (save-excursion
+    (forward-line (if N N 0))
+    (end-of-line)
+    (point)))
+
 (defun iedit-region-active ()
   "Return t if region is active and not empty.
 If variable `iedit-transient-mark-sensitive' is t, active region


### PR DESCRIPTION
It's nice to be able to run Iedit on only the current line or lines
near the current line. Provide functions to narrow the Iedit search
region to the current line and to expand the search region near the
current line ad-hoc.
