### PR TITLE
Option to clean up the occurrence string presented to the user

### DIFF
--- a/iedit-lib.el
+++ b/iedit-lib.el
@@ -838,17 +838,25 @@ Return nil if occurrence string is empty string."
 
 (defun iedit-printable (string)
   "Return a omitted substring that is not longer than 50.
-STRING is already `regexp-quote'ed"
-  (let ((first-newline-index (string-match "$" string))
-        (length (length string)))
+STRING is already `regexp-quote'ed.
+
+When  is non-nil, if extra characters were added to make this
+string only match symbols (i.e. if
+iedit-only-complete-symbol-local is non-nil) then strip those
+extra characters off."
+  (let* ((clean-string (if iedit-hide-added-symbol-regexp
+                           (iedit-regexp-maybe-unquote string)
+                         string))
+         (first-newline-index (string-match "$" clean-string))
+         (length (length clean-string)))
     (if (and first-newline-index
              (/= first-newline-index length))
         (if (< first-newline-index 50)
-            (concat (substring string 0 first-newline-index) "...")
-          (concat (substring string 0 50) "..."))
+            (concat (substring clean-string 0 first-newline-index) "...")
+          (concat (substring clean-string 0 50) "..."))
       (if (> length 50)
-          (concat (substring string 0 50) "...")
-        string))))
+          (concat (substring clean-string 0 50) "...")
+        clean-string))))
 
 (defun iedit-char-at-bol (&optional N)
   "Get char position of the beginning of the current line. If `N'

--- a/iedit.el
+++ b/iedit.el
@@ -99,6 +99,14 @@ For example, when invoking command `iedit-mode' on the \"in\" in the
   :type 'vector
   :group 'iedit)
 
+(defcustom iedit-hide-added-symbol-regexp nil
+  "If non-nil, when the search string is augmented to become a
+regexp to match only
+symbols (e.g. `iedit-only-complete-symbol-local' and friends)
+those extra characters to form said regexp are stripped off."
+  :type 'boolean
+  :group 'iedit)
+
 (defvar iedit-mode-hook nil
   "Function(s) to call after starting up an iedit.")
 
@@ -402,6 +410,13 @@ Keymap used within overlays:
   (if iedit-only-complete-symbol-local
       (concat "\\_<" (regexp-quote exp) "\\_>")
     (regexp-quote exp)))
+
+(defun iedit-regexp-maybe-unquote (exp)
+  "Strip off the extra regexp characters that
+`iedit-regexp-quote' adds to a string."
+  (if iedit-only-complete-symbol-local
+      (substring exp 3 (- (length exp) 3))
+    exp))
 
 (defun iedit-start2 (occurrence-regexp beg end)
   "Refresh Iedit mode."


### PR DESCRIPTION
If `iedit-only-complete-symbol-*' is being used then there are some
extra characters added to the occurrence string which make the string
a regexp to only match symbols. The user might not want to see the
extra characters needed to form the regexp. Provide an option to strip
off the added characters when presenting the occurrence string to the
user.
