### PR TITLE
Minor bugfix: `help-char' need not be acceptable to `char-to-string'.

### DIFF
--- a/iedit.el
+++ b/iedit.el
@@ -161,7 +161,7 @@ An example of how to use this variable: todo")
 
 (defvar iedit-help-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (char-to-string help-char) 'iedit-help-for-help)
+    (define-key map (vector (event-convert-list `(,help-char))) 'iedit-help-for-help)
     (define-key map [help] 'iedit-help-for-help)
     (define-key map [f1] 'iedit-help-for-help)
     (define-key map "?" 'iedit-help-for-help)
@@ -246,7 +246,7 @@ This is like `describe-bindings', but displays only Iedit keys."
 (defvar iedit-mode-keymap
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map iedit-lib-keymap)
-    (define-key map (char-to-string help-char) iedit-help-map)
+    (define-key map (vector (event-convert-list `(,help-char))) iedit-help-map)
     (define-key map [help] iedit-help-map)
     (define-key map [f1] iedit-help-map)
     (define-key map (kbd "M-;") 'iedit-toggle-selection)


### PR DESCRIPTION
Would you consider this minor change.  The motivation is that I have configured my copy of Emacs to use M-<some_char> as a `help-char`, and `char-to-sring` cannot handle such characters (try evaluating `(char-to-string ?\M-a)` in  the *scratch* buffer to see what I mean).  I believe the way of writing keyboard events that I have in this patch works in all "reasonably recent" versions of Emacs (also `git log keyboard.c | grep event-convert`) suggests that event-convert-list has been in Emacs for a while.