### PR TITLE
iedit-restrict-current-line resets expand state

### DIFF
--- a/iedit.el
+++ b/iedit.el
@@ -529,6 +529,8 @@ the initial string globally."
   "Restrict Iedit mode to current line."
   (interactive)
   (iedit-restrict-region (iedit-char-at-bol) (iedit-char-at-eol))
+  (setq iedit-num-lines-to-expand-up 0
+        iedit-num-lines-to-expand-down 0)
   (message "Restricted to current line, %d match%s."
            (length iedit-occurrences-overlays)
            (if (= 1 (length iedit-occurrences-overlays)) "" "es")))


### PR DESCRIPTION
iedit-restrict-current-line now resets iedit-num-lines-to-expand-up and
iedit-num-lines-to-expand-down to 0. This matches the behavior described
in the doc strings for iedit-expand-by-a-line, iedit-expand-up-a-line,
and iedit-expand-down-a-line, and makes it possible to reset the
expansion range without exiting iedit-mode.

Fixes https://github.com/victorhge/iedit/issues/50 .