### PR TITLE
avoid error if iedit-toggle-key-default already bound to iedit-mode

### DIFF
--- a/iedit.el
+++ b/iedit.el
@@ -220,7 +220,7 @@ This is like `describe-bindings', but displays only Iedit keys."
 ;;; Default key bindings:
 (when iedit-toggle-key-default
   (let ((key-def (lookup-key (current-global-map) iedit-toggle-key-default)))
-    (if key-def
+    (if (and key-def (not (eq key-def 'iedit-mode)))
         (display-warning 'iedit (format "Iedit default key %S is occupied by %s."
                                         (key-description iedit-toggle-key-default)
                                         key-def)


### PR DESCRIPTION
This adjusts the check in issue 59 to avoid triggering an error if the `iedit-toggle-key-default` is already bound to `'iedit-mode`.  A common use case would be users of *use-package* who wish to defer loading of `iedit-mode`; in which case the key-binding already exists in the global map.