### PR TITLE
Readme.org: add melpa/stable version badges

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,4 +1,7 @@
 * Iedit - Edit multiple regions in the same way simultaneously
+[[http://melpa.org/#/iedit][file:http://melpa.org/packages/iedit-badge.svg]]
+[[http://stable.melpa.org/#/iedit][file:http://stable.melpa.org/packages/iedit-badge.svg]]
+
 [[./iedit-demo.gif]]
 ** Introduction
 This package includes Emacs minor modes (iedit-mode and


### PR DESCRIPTION
Melpa badges makes the current versions readily accessible from the repositories main page.