### PR TITLE
iedit-rect.el: Don't set iedit-initial-string-local

### DIFF
--- a/iedit-rect.el
+++ b/iedit-rect.el
@@ -121,7 +121,6 @@ Commands:
   (setq beg (copy-marker beg))
   (setq end (copy-marker end t))
   (setq iedit-occurrences-overlays nil)
-  (setq iedit-initial-string-local nil)
   (setq iedit-occurrence-keymap iedit-rect-keymap)
   (save-excursion
     (let ((beg-col (progn (goto-char beg) (current-column)))


### PR DESCRIPTION
* `iedit-rect.el` (`iedit-rectangle-start`): Delete initialization of the `iedit-initial-string-local` variable, which is only used in `iedit.el`, in order to silence the byte compiler.
