### PR TITLE
Fix bug #115. Now properly disable iedit-mode during desktop restore.

### DIFF
--- a/iedit.el
+++ b/iedit.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2010, 2011, 2012 Victor Ren
 
-;; Time-stamp: <2020-07-21 13:52:42 Victor Ren>
+;; Time-stamp: <2020-11-01 14:45:02, updated by Pierre Rouleau>
 ;; Author: Victor Ren <victorhge@gmail.com>
 ;; Keywords: occurrence region simultaneous refactoring
 ;; Version: 0.9.9.9
@@ -279,7 +279,7 @@ This is like `describe-bindings', but displays only Iedit keys."
 
 ;; Avoid to restore Iedit mode when restoring desktop
 (add-to-list 'desktop-minor-mode-handlers
-             '(iedit-mode . nil))
+             '(iedit-mode . ignore))
 
 ;;; Define iedit help map.
 (eval-when-compile (require 'help-macro))
@@ -714,7 +714,7 @@ line.  N defaults to 1.  If N is negative, collapses the top of
 the search region by `-N' lines."
   (interactive "p")
   (iedit-expand-by-a-line 'top N))
-  
+
 (defun iedit-expand-down-a-line (&optional N)
   "After start iedit-mode only on current symbol or the active
 region, this function expands the search region downwards by N


### PR DESCRIPTION
To fix this, the (ignore &rest IGNORE) function is used as the handler instead of nil. 

To properly de-activate restoration of iedit-mode when desktop is restoring them a function is required as handler. Specifying nil as it was done before tells desktop that no handler exists.  See the code in desktop.el which includes the following form inside desktop-create-buffer:

```elisp
          (cond ((equal '(t) desktop-buffer-minor-modes) ; backwards compatible                                                                                                                                                
                 (auto-fill-mode 1))
		((equal '(nil) desktop-buffer-minor-modes) ; backwards compatible                                                                                                                                              
                 (auto-fill-mode 0))
		(t
                 (dolist (minor-mode desktop-buffer-minor-modes)
                   ;; Give minor mode module a chance to add a handler.                                                                                                                                                        
                   (desktop-load-file minor-mode)
                   (let ((handler (cdr (assq minor-mode desktop-minor-mode-handlers))))
                     (if handler
                         (funcall handler desktop-buffer-locals)
                       (when (functionp minor-mode)
                         (funcall minor-mode 1)))))))
```

In there, the 
```elisp
                     (if handler
```
will evaluate to false when the handler is nil and the (funcall minor-mode 1) will execute as (iedit-mode 1).  

Using the ignore function fixes the problem: ignore is identified as the handler, it is called, but it does nothing.