### PR TITLE
Add more setup into `iedit-lib-start'

### DIFF
--- a/iedit-lib.el
+++ b/iedit-lib.el
@@ -405,10 +405,20 @@ there are."
     (iedit-update-index)
     )) ;; todo test this function
 
+(defvar iedit-mode)
+
 (defun iedit-lib-start ()
   "Initialize the hooks."
+  (setq iedit-mode t)
+  (when iedit-auto-buffering
+    (iedit-start-buffering))
   (add-hook 'post-command-hook 'iedit-update-occurrences-2 nil t)
-  (setq iedit-after-change-list nil))
+  (setq iedit-after-change-list nil)
+  (run-hooks 'iedit-mode-hook)
+  (add-hook 'before-revert-hook 'iedit-done nil t)
+  (add-hook 'kbd-macro-termination-hook 'iedit-done nil t)
+  (add-hook 'change-major-mode-hook 'iedit-done nil t)
+  (add-hook 'iedit-aborting-hook 'iedit-done nil t))
 
 (defun iedit-lib-cleanup ()
   "Clean up occurrence overlay, invisible overlay and local variables."

--- a/iedit.el
+++ b/iedit.el
@@ -463,17 +463,6 @@ Keymap used within overlays:
            (message "Matches are not the same length.")
            (iedit-done)))))
 
-(defun iedit-begin ()
-  "Set-up `iedit' for custom `iedit-occurrences-overlays'."
-  (setq iedit-mode t)
-  (when iedit-auto-buffering
-    (iedit-start-buffering))
-  (run-hooks 'iedit-mode-hook)
-  (add-hook 'before-revert-hook 'iedit-done nil t)
-  (add-hook 'kbd-macro-termination-hook 'iedit-done nil t)
-  (add-hook 'change-major-mode-hook 'iedit-done nil t)
-  (add-hook 'iedit-aborting-hook 'iedit-done nil t))
-
 (defun iedit-start (occurrence-regexp beg end)
   "Start Iedit mode for the `occurrence-regexp' in the current buffer."
   ;; enforce skip modification once, errors may happen to cause this to be
@@ -491,7 +480,7 @@ Keymap used within overlays:
     (message "%d matches for \"%s\""
              counter
              (iedit-printable occurrence-regexp)))
-  (iedit-begin))
+  (iedit-lib-start))
 
 (defun iedit-default-occurrence()
   "This function returns a string as occurrence candidate.

--- a/iedit.el
+++ b/iedit.el
@@ -463,6 +463,17 @@ Keymap used within overlays:
            (message "Matches are not the same length.")
            (iedit-done)))))
 
+(defun iedit-begin ()
+  "Set-up `iedit' for custom `iedit-occurrences-overlays'."
+  (setq iedit-mode t)
+  (when iedit-auto-buffering
+    (iedit-start-buffering))
+  (run-hooks 'iedit-mode-hook)
+  (add-hook 'before-revert-hook 'iedit-done nil t)
+  (add-hook 'kbd-macro-termination-hook 'iedit-done nil t)
+  (add-hook 'change-major-mode-hook 'iedit-done nil t)
+  (add-hook 'iedit-aborting-hook 'iedit-done nil t))
+
 (defun iedit-start (occurrence-regexp beg end)
   "Start Iedit mode for the `occurrence-regexp' in the current buffer."
   ;; enforce skip modification once, errors may happen to cause this to be
@@ -479,16 +490,8 @@ Keymap used within overlays:
       (setq counter (iedit-make-occurrences-overlays occurrence-regexp beg end)))
     (message "%d matches for \"%s\""
              counter
-             (iedit-printable occurrence-regexp))
-    (setq iedit-mode t))
-  (when iedit-auto-buffering
-	(iedit-start-buffering))
-  (iedit-lib-start)
-  (run-hooks 'iedit-mode-hook)
-  (add-hook 'before-revert-hook 'iedit-done nil t)
-  (add-hook 'kbd-macro-termination-hook 'iedit-done nil t)
-  (add-hook 'change-major-mode-hook 'iedit-done nil t)
-  (add-hook 'iedit-aborting-hook 'iedit-done nil t))
+             (iedit-printable occurrence-regexp)))
+  (iedit-begin))
 
 (defun iedit-default-occurrence()
   "This function returns a string as occurrence candidate.


### PR DESCRIPTION
`iedit-start` consists of two parts: scanning for a regex, and setting-up
various hooks so that `iedit` works correctly (`iedit-done`, ...).

The latter part is useful in isolation if there is a custom way to acquire
`iedit-occurrences-overlays`, as is the case with `lsp-mode`, which recently got
`iedit` integration. This way, the `add-hook` blocks no longer need to be
duplicated in such packages.

See [lsp-mode](https://github.com/emacs-lsp/lsp-mode/blob/053c1818777b0a7997da04a4fc91f5391785e664/lsp-iedit.el#L47).

Also, a question: it doesn't seem like `iedit-lib` can be used directly without `require`ing `iedit`, because otherwise `iedit-mode-keymap` would be unavailable, as would be `iedit-done`. Am I missing something here?