### PR TITLE
Bump the version to 0.9.10 for NonGNU ELPA

### DIFF
--- a/iedit.el
+++ b/iedit.el
@@ -5,7 +5,7 @@
 ;; Time-stamp: <2021-12-23 18:27:46 Victor Ren>
 ;; Author: Victor Ren <victorhge@gmail.com>
 ;; Keywords: occurrence region simultaneous refactoring
-;; Version: 0.9.9.9
+;; Version: 0.9.10
 ;; X-URL: https://github.com/victorhge/iedit
 ;;        https://www.emacswiki.org/emacs/Iedit
 ;; Compatibility: GNU Emacs: 22.x, 23.x, 24.x, 25.x


### PR DESCRIPTION
I am preparing to add this package to NonGNU ELPA, a new package repository that will be enabled by default in Emacs 28. This means that users will be able to install this package without any further configuration needed on their part: they can just run `M-x list-packages` and install it out of the box.

The main difference between NonGNU ELPA and MELPA is that only tagged versions of packages are released. This means that a new release will only be packaged when you bump the "Version" header, in the same way as I do in this commit. You are free to bump the package version (thereby releasing a new version) whenever you think it makes sense to release a new version to users of NonGNU ELPA.

Please let me know if you have any questions about any of this.

Thanks!